### PR TITLE
Fix attribute regex matching

### DIFF
--- a/Fuzi/Queryable.swift
+++ b/Fuzi/Queryable.swift
@@ -256,7 +256,7 @@ private class RegexConstants {
   
   static let classRegex = try! RegularExpression(pattern: "\\.([^\\.]+)", options: [])
   
-  static let attributeRegex = try! RegularExpression(pattern: "\\[(.+)\\]", options: [])
+  static let attributeRegex = try! RegularExpression(pattern: "\\[([^\\[\\]]+)\\]", options: [])
 }
 
 internal func XPath(fromCSS css: String) -> String {

--- a/Fuzi/Queryable.swift
+++ b/Fuzi/Queryable.swift
@@ -256,7 +256,7 @@ private class RegexConstants {
   
   static let classRegex = try! RegularExpression(pattern: "\\.([^\\.]+)", options: [])
   
-  static let attributeRegex = try! RegularExpression(pattern: "\\[(\\w+)\\]", options: [])
+  static let attributeRegex = try! RegularExpression(pattern: "\\[(.+)\\]", options: [])
 }
 
 internal func XPath(fromCSS css: String) -> String {

--- a/FuziTests/CSSTests.swift
+++ b/FuziTests/CSSTests.swift
@@ -71,6 +71,14 @@ class CSSTests: XCTestCase {
     XCTAssertEqual(XPath(fromCSS:"img[alt]"), ".//img[@alt]")
   }
   
+  func testCSSAttributeValueSelector() {
+    XCTAssertEqual(XPath(fromCSS:"a[rel='next']"), ".//a[@rel='next']")
+  }
+    
+  func testCSSMultipleAttributesSelector() {
+    XCTAssertEqual(XPath(fromCSS:"a[rel='next'][href='/foo/bar']"), ".//a[@rel='next'][@href='/foo/bar']")
+  }
+  
   func testCSSAttributeSelector() {
     XCTAssertEqual(XPath(fromCSS:"ul, ol"), ".//ul | .//ol")
   }


### PR DESCRIPTION
It used to work well but since using Swift 3 (or so it seems), the attributeRegex only matches css attributes without values. For example, "a[rel]" is correctly interpreted as ".//a[@rel]" but "a[rel='next']" isn't matched so it returns only ".//a", therefore catching all anchors in the HTML document. Because you can put quite anything as a value of an attribute, matching any character inside the brackets seems to be the right solution.
I tested it with various attribute names and values and it seems to transform them into XPath quite fine.