### PR TITLE
Update for Xcode 8 beta 6

### DIFF
--- a/Fuzi/Document.swift
+++ b/Fuzi/Document.swift
@@ -23,17 +23,17 @@ import Foundation
 import libxml2
 
 /// XML document which can be searched and queried.
-public class XMLDocument {
+open class XMLDocument {
   // MARK: - Document Attributes
   /// The XML version.
-  public private(set) lazy var version: String? = {
+  open fileprivate(set) lazy var version: String? = {
     return ^-^self.cDocument.pointee.version
   }()
   
   /// The string encoding for the document. This is NSUTF8StringEncoding if no encoding is set, or it cannot be calculated.
-  public private(set) lazy var encoding: String.Encoding = {
+  open fileprivate(set) lazy var encoding: String.Encoding = {
     if let encodingName = ^-^self.cDocument.pointee.encoding {
-      let encoding = CFStringConvertIANACharSetNameToEncoding(encodingName)
+      let encoding = CFStringConvertIANACharSetNameToEncoding(encodingName as CFString!)
       if encoding != kCFStringEncodingInvalidId {
         return String.Encoding(rawValue: UInt(CFStringConvertEncodingToNSStringEncoding(encoding)))
       }
@@ -43,18 +43,18 @@ public class XMLDocument {
 
   // MARK: - Accessing the Root Element
   /// The root element of the document.
-  public private(set) var root: XMLElement?
+  open fileprivate(set) var root: XMLElement?
   
   // MARK: - Accessing & Setting Document Formatters
   /// The formatter used to determine `numberValue` for elements in the document. By default, this is an `NSNumberFormatter` instance with `NSNumberFormatterDecimalStyle`.
-  public lazy var numberFormatter: NumberFormatter = {
+  open lazy var numberFormatter: NumberFormatter = {
     let formatter = NumberFormatter()
     formatter.numberStyle = .decimal
     return formatter
   }()
   
   /// The formatter used to determine `dateValue` for elements in the document. By default, this is an `NSDateFormatter` instance configured to accept ISO 8601 formatted timestamps.
-  public lazy var dateFormatter: DateFormatter = {
+  open lazy var dateFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.locale = Locale(identifier: "en_US_POSIX")
     formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
@@ -62,7 +62,7 @@ public class XMLDocument {
   }()
   
   // MARK: - Creating XML Documents
-  private let cDocument: xmlDocPtr
+  fileprivate let cDocument: xmlDocPtr
   
   /**
   Creates and returns an instance of XMLDocument from an XML string, throwing XMLError if an error occured while parsing the XML.
@@ -91,7 +91,7 @@ public class XMLDocument {
   - returns: An `XMLDocument` with the contents of the specified XML string.
   */
   public convenience init(data: NSData) throws {
-    try self.init(cChars: [CChar](UnsafeBufferPointer(start: UnsafePointer(data.bytes), count: data.length)))
+    try self.init(cChars: [CChar](UnsafeBufferPointer(start: data.bytes.assumingMemoryBound(to: CChar.self), count: data.length)))
   }
   
   /**
@@ -108,13 +108,13 @@ public class XMLDocument {
     try self.init(cChars: cChars, options: options)
   }
   
-  private typealias ParseFunction = (UnsafePointer<Int8>?, Int32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32) -> xmlDocPtr?
+  fileprivate typealias ParseFunction = (UnsafePointer<Int8>?, Int32, UnsafePointer<Int8>?, UnsafePointer<Int8>?, Int32) -> xmlDocPtr?
   
-  private convenience init(cChars: [CChar], options: Int32) throws {
+  fileprivate convenience init(cChars: [CChar], options: Int32) throws {
     try self.init(parseFunction: { xmlReadMemory($0, $1, $2, $3, $4) }, cChars: cChars, options: options)
   }
   
-  private convenience init(parseFunction: ParseFunction, cChars: [CChar], options: Int32) throws {
+  fileprivate convenience init(parseFunction: ParseFunction, cChars: [CChar], options: Int32) throws {
     guard let document = parseFunction(UnsafePointer(cChars), Int32(cChars.count), "", nil, options) else {
       throw XMLError.lastError(defaultError: .parserFailure)
     }
@@ -122,7 +122,7 @@ public class XMLDocument {
     self.init(cDocument: document)
   }
   
-  private init(cDocument: xmlDocPtr) {
+  fileprivate init(cDocument: xmlDocPtr) {
     self.cDocument = cDocument
     // cDocument shall not be nil
     root = XMLElement(cNode: xmlDocGetRootElement(cDocument), document: self)
@@ -141,7 +141,7 @@ public class XMLDocument {
   - parameter prefix: The prefix name
   - parameter ns:     The default namespace URI that declared in XML Document
   */
-  public func definePrefix(_ prefix: String, defaultNamespace ns: String) {
+  open func definePrefix(_ prefix: String, defaultNamespace ns: String) {
     defaultNamespaces[ns] = prefix
   }
 }
@@ -161,21 +161,21 @@ public func ==(lhs: XMLDocument, rhs: XMLDocument) -> Bool {
 }
 
 /// HTML document which can be searched and queried.
-public class HTMLDocument: XMLDocument {
+open class HTMLDocument: XMLDocument {
   // MARK: - Convenience Accessors
   
   /// HTML title of current document
-  public var title: String? {
+  open var title: String? {
     return root?.firstChild(tag: "head")?.firstChild(tag: "title")?.stringValue
   }
   
   /// HTML head element of current document
-  public var head: XMLElement? {
+  open var head: XMLElement? {
     return root?.firstChild(tag: "head")
   }
   
   /// HTML body element of current document
-  public var body: XMLElement? {
+  open var body: XMLElement? {
     return root?.firstChild(tag: "body")
   }
   
@@ -194,7 +194,7 @@ public class HTMLDocument: XMLDocument {
     try self.init(cChars: cChars, options: options)
   }
   
-  private convenience init(cChars: [CChar], options: Int32) throws {
+  fileprivate convenience init(cChars: [CChar], options: Int32) throws {
     try self.init(parseFunction: { htmlReadMemory($0, $1, $2, $3, $4) }, cChars: cChars, options: options)
   }
 }

--- a/Fuzi/Element.swift
+++ b/Fuzi/Element.swift
@@ -23,21 +23,21 @@ import Foundation
 import libxml2
 
 /// Represents an element in `XMLDocument` or `HTMLDocument`
-public class XMLElement: XMLNode {
+open class XMLElement: XMLNode {
   
   /// The element's namespace.
-  public private(set) lazy var namespace: String? = {
+  open fileprivate(set) lazy var namespace: String? = {
     return ^-^(self.cNode.pointee.ns != nil ?self.cNode.pointee.ns.pointee.prefix :nil)
   }()
   
   /// The element's tag.
-  public private(set) lazy var tag: String? = {
+  open fileprivate(set) lazy var tag: String? = {
     return ^-^self.cNode.pointee.name
   }()
   
   // MARK: - Accessing Attributes
   /// All attributes for the element.
-  public private(set) lazy var attributes: [String : String] = {
+  open fileprivate(set) lazy var attributes: [String : String] = {
     var attributes = [String: String]()
     var attribute = self.cNode.pointee.properties
     while attribute != nil {
@@ -57,7 +57,7 @@ public class XMLElement: XMLNode {
    
    - returns: The attribute value, or `nil` if the attribute is not defined.
    */
-  public func attr(_ name: String, namespace ns: String? = nil) -> String? {
+  open func attr(_ name: String, namespace ns: String? = nil) -> String? {
     var value: String? = nil
     
     let xmlValue: UnsafeMutablePointer<xmlChar>?
@@ -77,7 +77,7 @@ public class XMLElement: XMLNode {
   // MARK: - Accessing Children
   
   /// The element's children elements.
-  public var children: [XMLElement] {
+  open var children: [XMLElement] {
     return LinkedCNodes(head: cNode.pointee.children).flatMap {
       XMLElement(cNode: $0, document: self.document)
     }
@@ -90,7 +90,7 @@ public class XMLElement: XMLNode {
    
   - returns: all children of specified types
   */
-  public func childNodes(ofTypes types: [XMLNodeType]) -> [XMLNode] {
+  open func childNodes(ofTypes types: [XMLNodeType]) -> [XMLNode] {
     return LinkedCNodes(head: cNode.pointee.children, types: types).flatMap { node in
       switch node.pointee.type {
       case XMLNodeType.Element:
@@ -109,7 +109,7 @@ public class XMLElement: XMLNode {
   
   - returns: The child element.
   */
-  public func firstChild(tag: String, inNamespace ns: String? = nil) -> XMLElement? {
+  open func firstChild(tag: String, inNamespace ns: String? = nil) -> XMLElement? {
     var nodePtr = cNode.pointee.children
     while let cNode = nodePtr {
       if cXMLNode(nodePtr, matchesTag: tag, inNamespace: ns) {
@@ -128,7 +128,7 @@ public class XMLElement: XMLNode {
   
   - returns: The children elements.
   */
-  public func children(tag: String, inNamespace ns: String? = nil) -> [XMLElement] {
+  open func children(tag: String, inNamespace ns: String? = nil) -> [XMLElement] {
     return LinkedCNodes(head: cNode.pointee.children).flatMap {
       cXMLNode($0, matchesTag: tag, inNamespace: ns)
         ? XMLElement(cNode: $0, document: self.document) : nil
@@ -137,17 +137,17 @@ public class XMLElement: XMLNode {
   
   // MARK: - Accessing Content
   /// Whether the element has a value.
-  public var isBlank: Bool {
+  open var isBlank: Bool {
     return stringValue.isEmpty
   }
   
   /// A number representation of the element's value, which is generated from the document's `numberFormatter` property.
-  public private(set) lazy var numberValue: NSNumber? = {
+  open fileprivate(set) lazy var numberValue: NSNumber? = {
     return self.document.numberFormatter.number(from: self.stringValue)
   }()
   
   /// A date representation of the element's value, which is generated from the document's `dateFormatter` property.
-  public private(set) lazy var dateValue: Date? = {
+  open fileprivate(set) lazy var dateValue: Date? = {
     return self.document.dateFormatter.date(from: self.stringValue)
   }()
   
@@ -158,7 +158,7 @@ public class XMLElement: XMLNode {
   
   - returns: The child element.
   */
-  public subscript (idx: Int) -> XMLElement? {
+  open subscript (idx: Int) -> XMLElement? {
     return children[idx]
   }
   
@@ -169,7 +169,7 @@ public class XMLElement: XMLNode {
   
   - returns: The attribute value, or `nil` if the attribute is not defined.
   */
-  public subscript (name: String) -> String? {
+  open subscript (name: String) -> String? {
     return attr(name)
   }
 }

--- a/Fuzi/Helpers.swift
+++ b/Fuzi/Helpers.swift
@@ -56,23 +56,23 @@ internal extension String {
   subscript (nsrange: NSRange) -> String {
     let start = utf16.index(utf16.startIndex, offsetBy: nsrange.location)
     let end = utf16.index(start, offsetBy: nsrange.length)
-    return String(utf16[start..<end])
+    return String(utf16[start..<end])!
   }
 }
 
 // Just a smiling helper operator making frequent UnsafePointer -> String cast
 
-prefix operator ^-^ {}
+prefix operator ^-^
 internal prefix func ^-^ <T> (ptr: UnsafePointer<T>?) -> String? {
   if let ptr = ptr {
-    return String(validatingUTF8: UnsafePointer(ptr))
+    return String(validatingUTF8: UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self))
   }
   return nil
 }
 
 internal prefix func ^-^ <T> (ptr: UnsafeMutablePointer<T>?) -> String? {
   if let ptr = ptr {
-    return String(validatingUTF8: UnsafeMutablePointer(ptr))
+    return String(validatingUTF8: UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self))
   }
   return nil
 }
@@ -81,7 +81,7 @@ internal struct LinkedCNodes: Sequence, IteratorProtocol {
   internal let head: xmlNodePtr?
   internal let types: [xmlElementType]
   
-  private var cursor: xmlNodePtr?
+  fileprivate var cursor: xmlNodePtr?
   mutating func next() -> xmlNodePtr? {
     defer {
       if let ptr = cursor {

--- a/Fuzi/Node.swift
+++ b/Fuzi/Node.swift
@@ -72,7 +72,7 @@ extension XMLNodeType {
   public static var DocbDocument: xmlElementType  { return XML_DOCB_DOCUMENT_NODE }
 }
 
-infix operator ~= {}
+infix operator ~=
 /**
  For supporting pattern matching of those enum case alias getters for XMLNodeType
  
@@ -86,44 +86,44 @@ public func ~=(lhs: XMLNodeType, rhs: XMLNodeType) -> Bool {
 }
 
 /// Base class for all XML nodes
-public class XMLNode {
+open class XMLNode {
   /// The document containing the element.
-  public unowned let document: XMLDocument
+  open unowned let document: XMLDocument
   
   /// The type of the XMLNode
-  public var type: XMLNodeType {
+  open var type: XMLNodeType {
     return cNode.pointee.type
   }
   
   /// The element's line number.
-  public private(set) lazy var lineNumber: Int = {
+  open fileprivate(set) lazy var lineNumber: Int = {
     return xmlGetLineNo(self.cNode)
   }()
   
   // MARK: - Accessing Parent and Sibling Elements
   /// The element's parent element.
-  public private(set) lazy var parent: XMLElement? = {
+  open fileprivate(set) lazy var parent: XMLElement? = {
     return XMLElement(cNode: self.cNode.pointee.parent, document: self.document)
   }()
   
   /// The element's next sibling.
-  public private(set) lazy var previousSibling: XMLElement? = {
+  open fileprivate(set) lazy var previousSibling: XMLElement? = {
     return XMLElement(cNode: self.cNode.pointee.prev, document: self.document)
   }()
   
   /// The element's previous sibling.
-  public private(set) lazy var nextSibling: XMLElement? = {
+  open fileprivate(set) lazy var nextSibling: XMLElement? = {
     return XMLElement(cNode: self.cNode.pointee.next, document: self.document)
   }()
   
   // MARK: - Accessing Contents
   /// Whether this is a HTML node
-  public var isHTML: Bool {
+  open var isHTML: Bool {
     return UInt32(self.cNode.pointee.doc.pointee.properties) & XML_DOC_HTML.rawValue == XML_DOC_HTML.rawValue
   }
 
   /// A string representation of the element's value.
-  public private(set) lazy var stringValue : String = {
+  open fileprivate(set) lazy var stringValue : String = {
     let key = xmlNodeGetContent(self.cNode)
     let stringValue = ^-^key ?? ""
     xmlFree(key)
@@ -131,7 +131,7 @@ public class XMLNode {
   }()
   
   /// The raw XML string of the element.
-  public private(set) lazy var rawXML: String = {
+  open fileprivate(set) lazy var rawXML: String = {
     let buffer = xmlBufferCreate()
     if self.isHTML {
       htmlNodeDump(buffer, self.cNode.pointee.doc, self.cNode)
@@ -144,7 +144,7 @@ public class XMLNode {
   }()
   
  /// Convert this node to XMLElement if it is an element node
-  public func toElement() -> XMLElement? {
+  open func toElement() -> XMLElement? {
     return self as? XMLElement
   }
   

--- a/Fuzi/NodeSet.swift
+++ b/Fuzi/NodeSet.swift
@@ -23,15 +23,15 @@ import Foundation
 import libxml2
 
 /// An enumerable set of XML nodes
-public class NodeSet: Collection {
+open class NodeSet: Collection {
   // Index type for `Indexable` protocol
   public typealias Index = Int
 
   // IndexDistance type for `Indexable` protocol
   public typealias IndexDistance = Int
   
-  private var cursor = 0
-  public func next() -> XMLElement? {
+  fileprivate var cursor = 0
+  open func next() -> XMLElement? {
     defer {
       cursor += 1
     }
@@ -42,27 +42,27 @@ public class NodeSet: Collection {
   }
 
   /// Number of nodes
-  public private(set) lazy var count: Int = {
+  open fileprivate(set) lazy var count: Int = {
     return Int(self.cNodeSet?.pointee.nodeNr ?? 0)
   }()
   
   /// First Element
-  public var first: XMLElement? {
+  open var first: XMLElement? {
     return count > 0 ? self[startIndex] : nil
   }
 
   /// if nodeset is empty
-  public var isEmpty: Bool {
+  open var isEmpty: Bool {
     return (cNodeSet == nil) || (cNodeSet!.pointee.nodeNr == 0) || (cNodeSet!.pointee.nodeTab == nil)
   }
 
   /// Start index
-  public var startIndex: Index {
+  open var startIndex: Index {
     return 0
   }
 
   /// End index
-  public var endIndex: Index {
+  open var endIndex: Index {
     return count
   }
 
@@ -73,7 +73,7 @@ public class NodeSet: Collection {
 
    - returns: the idx'th node, nil if out of range
   */
-  public subscript(_ idx: Index) -> XMLElement {
+  open subscript(_ idx: Index) -> XMLElement {
     _precondition(idx >= startIndex && idx < endIndex, "Index of out bound")
     return XMLElement(cNode: (cNodeSet!.pointee.nodeTab[idx])!, document: document)
   }
@@ -85,7 +85,7 @@ public class NodeSet: Collection {
 
    - returns: the index after `idx`
    */
-  public func index(after idx: Index) -> Index {
+  open func index(after idx: Index) -> Index {
     return idx + 1
   }
   
@@ -99,11 +99,11 @@ public class NodeSet: Collection {
 }
 
 /// XPath selector result node set
-public class XPathNodeSet: NodeSet {
+open class XPathNodeSet: NodeSet {
   /// Empty node set
-  public static let emptySet = XPathNodeSet(cXPath: nil, document: nil)
+  open static let emptySet = XPathNodeSet(cXPath: nil, document: nil)
 
-  private var cXPath: xmlXPathObjectPtr?
+  fileprivate var cXPath: xmlXPathObjectPtr?
   
   internal init(cXPath: xmlXPathObjectPtr?, document: XMLDocument?) {
     self.cXPath = cXPath

--- a/Fuzi/Queryable.swift
+++ b/Fuzi/Queryable.swift
@@ -73,23 +73,23 @@ public protocol Queryable {
 }
 
 /// Result for evaluating a XPath expression
-public class XPathFunctionResult {
+open class XPathFunctionResult {
   /// Boolean value
-  public private(set) lazy var boolValue: Bool = {
+  open fileprivate(set) lazy var boolValue: Bool = {
     return self.cXPath.pointee.boolval != 0
   }()
   
   /// Double value
-  public private(set) lazy var doubleValue: Double = {
+  open fileprivate(set) lazy var doubleValue: Double = {
     return self.cXPath.pointee.floatval
   }()
   
   /// String value
-  public private(set) lazy var stringValue: String = {
+  open fileprivate(set) lazy var stringValue: String = {
     return ^-^self.cXPath.pointee.stringval ?? ""
   }()
   
-  private let cXPath: xmlXPathObjectPtr
+  fileprivate let cXPath: xmlXPathObjectPtr
   internal init?(cXPath: xmlXPathObjectPtr?) {
     guard let cXPath = cXPath else {
       return nil
@@ -218,7 +218,7 @@ extension XMLElement: Queryable {
     return XPathFunctionResult(cXPath: cXPath(xpathString: xpath))
   }
   
-  private func cXPath(xpathString: String) -> xmlXPathObjectPtr? {
+  fileprivate func cXPath(xpathString: String) -> xmlXPathObjectPtr? {
     guard let context = xmlXPathNewContext(cNode.pointee.doc) else {
       return nil
     }
@@ -234,7 +234,9 @@ extension XMLElement: Queryable {
           
           if let defaultPrefix = document.defaultNamespaces[href] {
             prefixChars = defaultPrefix.cString(using: String.Encoding.utf8) ?? []
-            prefix = UnsafePointer(prefixChars)
+            prefixChars.withUnsafeBufferPointer {(cArray: UnsafeBufferPointer<CChar>) -> Void in
+                prefix = UnsafeRawPointer(cArray.baseAddress)?.assumingMemoryBound(to: xmlChar.self)
+            }
           }
         }
         if prefix != nil {


### PR DESCRIPTION
- Conversion between `UnsafePointer`of different types isn’t allowed anymore. Now using
the new `UnsafeRawPointer` for conversion
- Implicit Swift bridging is gone, now explicitly casting
- `public`/`private` changed to `open`/`fileprivate` using Xcode migrator

Tests all succeeded, hoping my fixes actually work (haven't been able to test inside my own project yet).