### PR TITLE
Add nil guard to nextSibling, previousSibling and parent

### DIFF
--- a/Fuzi.xcodeproj/project.pbxproj
+++ b/Fuzi.xcodeproj/project.pbxproj
@@ -62,7 +62,7 @@
 		793BCECE1BA1469D009695D6 /* XPathFunctionResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XPathFunctionResultTests.swift; sourceTree = "<group>"; };
 		799F461B1B90479F00E4CE2C /* AtomTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomTests.swift; sourceTree = "<group>"; };
 		799F46271B904CE500E4CE2C /* XMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLTests.swift; sourceTree = "<group>"; };
-		799F462F1B9454A100E4CE2C /* HTMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLTests.swift; sourceTree = "<group>"; };
+		799F462F1B9454A100E4CE2C /* HTMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = HTMLTests.swift; sourceTree = "<group>"; tabWidth = 2; };
 		799F46321B9543A800E4CE2C /* CSSTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSSTests.swift; sourceTree = "<group>"; };
 		799F46341B95A64700E4CE2C /* DefaultNamespaceXPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultNamespaceXPathTests.swift; sourceTree = "<group>"; };
 		799F46361B95B91D00E4CE2C /* VMAPTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VMAPTests.swift; sourceTree = "<group>"; };

--- a/Fuzi.xcodeproj/project.pbxproj
+++ b/Fuzi.xcodeproj/project.pbxproj
@@ -62,7 +62,7 @@
 		793BCECE1BA1469D009695D6 /* XPathFunctionResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XPathFunctionResultTests.swift; sourceTree = "<group>"; };
 		799F461B1B90479F00E4CE2C /* AtomTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomTests.swift; sourceTree = "<group>"; };
 		799F46271B904CE500E4CE2C /* XMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XMLTests.swift; sourceTree = "<group>"; };
-		799F462F1B9454A100E4CE2C /* HTMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = HTMLTests.swift; sourceTree = "<group>"; tabWidth = 2; };
+		799F462F1B9454A100E4CE2C /* HTMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = HTMLTests.swift; sourceTree = "<group>"; tabWidth = 4; };
 		799F46321B9543A800E4CE2C /* CSSTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSSTests.swift; sourceTree = "<group>"; };
 		799F46341B95A64700E4CE2C /* DefaultNamespaceXPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultNamespaceXPathTests.swift; sourceTree = "<group>"; };
 		799F46361B95B91D00E4CE2C /* VMAPTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VMAPTests.swift; sourceTree = "<group>"; };

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -103,17 +103,26 @@ open class XMLNode {
   // MARK: - Accessing Parent and Sibling Elements
   /// The element's parent element.
   open fileprivate(set) lazy var parent: XMLElement? = {
-    return XMLElement(cNode: self.cNode.pointee.parent, document: self.document)
-  }()
-  
-  /// The element's next sibling.
-  open fileprivate(set) lazy var previousSibling: XMLElement? = {
-    return XMLElement(cNode: self.cNode.pointee.prev, document: self.document)
+    guard let parent = self.cNode.pointee.parent else {
+        return nil
+    }
+    return XMLElement(cNode: parent, document: self.document)
   }()
   
   /// The element's previous sibling.
+  open fileprivate(set) lazy var previousSibling: XMLElement? = {
+    guard let prev = self.cNode.pointee.prev else {
+        return nil
+    }
+    return XMLElement(cNode: prev, document: self.document)
+  }()
+
+  /// The element's next sibling.
   open fileprivate(set) lazy var nextSibling: XMLElement? = {
-    return XMLElement(cNode: self.cNode.pointee.next, document: self.document)
+    guard let next = self.cNode.pointee.next else {
+        return nil
+    }
+    return XMLElement(cNode: next, document: self.document)
   }()
   
   // MARK: - Accessing Contents

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -104,7 +104,7 @@ open class XMLNode {
   /// The element's parent element.
   open fileprivate(set) lazy var parent: XMLElement? = {
     guard let parent = self.cNode.pointee.parent else {
-        return nil
+      return nil
     }
     return XMLElement(cNode: parent, document: self.document)
   }()
@@ -112,7 +112,7 @@ open class XMLNode {
   /// The element's previous sibling.
   open fileprivate(set) lazy var previousSibling: XMLElement? = {
     guard let prev = self.cNode.pointee.prev else {
-        return nil
+      return nil
     }
     return XMLElement(cNode: prev, document: self.document)
   }()
@@ -120,7 +120,7 @@ open class XMLNode {
   /// The element's next sibling.
   open fileprivate(set) lazy var nextSibling: XMLElement? = {
     guard let next = self.cNode.pointee.next else {
-        return nil
+      return nil
     }
     return XMLElement(cNode: next, document: self.document)
   }()

--- a/Tests/HTMLTests.swift
+++ b/Tests/HTMLTests.swift
@@ -118,4 +118,11 @@ class HTMLTests: XCTestCase {
     XCTAssertEqual(childNodes?.flatMap { $0.type == .Element ? $0 : nil }.count, 2, "should have 2 element nodes")
     XCTAssertEqual(childNodes?.flatMap { $0.type == .Text ? $0 : nil }.count, 3, "should have 3 text nodes")
   }
+
+  func testNextSiblingDoesNotCrash() {
+    var child = document.root?.children.first
+    while(child != nil) {
+      child = child?.nextSibling
+    }
+  }
 }


### PR DESCRIPTION
These methods was crashing when you called them and the pointee was nil. 