### PR TITLE
better performance in accessing children by tag name

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -119,13 +119,33 @@ open class XMLElement: XMLNode {
     }
     return nil
   }
-  
+
+  /**
+  Returns the first child element with a tag, or `nil` if no such element exists.
+  (StaticString version)
+
+  - parameter tag: The tag name.
+  - parameter ns:  The namespace, or `nil` by default if not using a namespace
+
+  - returns: The child element.
+  */
+  open func firstChild(staticTag tag: StaticString, inNamespace ns: StaticString? = nil) -> XMLElement? {
+    var nodePtr = cNode.pointee.children
+    while let cNode = nodePtr {
+      if cXMLNode(nodePtr, matchesTag: tag, inNamespace: ns) {
+        return XMLElement(cNode: cNode, document: self.document)
+      }
+      nodePtr = cNode.pointee.next
+    }
+    return nil
+  }
+
   /**
   Returns all children elements with the specified tag.
-  
+
   - parameter tag: The tag name.
   - parameter ns:  The namepsace, or `nil` by default if not using a namespace
-  
+
   - returns: The children elements.
   */
   open func children(tag: String, inNamespace ns: String? = nil) -> [XMLElement] {
@@ -134,7 +154,23 @@ open class XMLElement: XMLNode {
         ? XMLElement(cNode: $0, document: self.document) : nil
     }
   }
-  
+
+  /**
+  Returns all children elements with the specified tag.
+  (StaticString version)
+
+  - parameter tag: The tag name.
+  - parameter ns:  The namepsace, or `nil` by default if not using a namespace
+
+  - returns: The children elements.
+  */
+  open func children(staticTag tag: StaticString, inNamespace ns: StaticString? = nil) -> [XMLElement] {
+    return LinkedCNodes(head: cNode.pointee.children).flatMap {
+      cXMLNode($0, matchesTag: tag, inNamespace: ns)
+        ? XMLElement(cNode: $0, document: self.document) : nil
+    }
+  }
+
   // MARK: - Accessing Content
   /// Whether the element has a value.
   open var isBlank: Bool {

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -109,7 +109,7 @@ open class XMLElement: XMLNode {
   
   - returns: The child element.
   */
-  open func firstChild(tag: String, inNamespace ns: String? = nil) -> XMLElement? {
+  open func firstChild(tag: XMLCharsComparable, inNamespace ns: XMLCharsComparable? = nil) -> XMLElement? {
     var nodePtr = cNode.pointee.children
     while let cNode = nodePtr {
       if cXMLNode(nodePtr, matchesTag: tag, inNamespace: ns) {
@@ -120,24 +120,9 @@ open class XMLElement: XMLNode {
     return nil
   }
 
-  /**
-  Returns the first child element with a tag, or `nil` if no such element exists.
-  (StaticString version)
-
-  - parameter tag: The tag name.
-  - parameter ns:  The namespace, or `nil` by default if not using a namespace
-
-  - returns: The child element.
-  */
+  /// faster version of firstChild with string literals (explicitly typed as StaticString)
   open func firstChild(staticTag tag: StaticString, inNamespace ns: StaticString? = nil) -> XMLElement? {
-    var nodePtr = cNode.pointee.children
-    while let cNode = nodePtr {
-      if cXMLNode(nodePtr, matchesTag: tag, inNamespace: ns) {
-        return XMLElement(cNode: cNode, document: self.document)
-      }
-      nodePtr = cNode.pointee.next
-    }
-    return nil
+    return firstChild(tag: tag, inNamespace: ns)
   }
 
   /**
@@ -148,27 +133,16 @@ open class XMLElement: XMLNode {
 
   - returns: The children elements.
   */
-  open func children(tag: String, inNamespace ns: String? = nil) -> [XMLElement] {
+  open func children(tag: XMLCharsComparable, inNamespace ns: XMLCharsComparable? = nil) -> [XMLElement] {
     return LinkedCNodes(head: cNode.pointee.children).flatMap {
       cXMLNode($0, matchesTag: tag, inNamespace: ns)
         ? XMLElement(cNode: $0, document: self.document) : nil
     }
   }
 
-  /**
-  Returns all children elements with the specified tag.
-  (StaticString version)
-
-  - parameter tag: The tag name.
-  - parameter ns:  The namepsace, or `nil` by default if not using a namespace
-
-  - returns: The children elements.
-  */
+  /// faster version of children with string literals (explicitly typed as StaticString)
   open func children(staticTag tag: StaticString, inNamespace ns: StaticString? = nil) -> [XMLElement] {
-    return LinkedCNodes(head: cNode.pointee.children).flatMap {
-      cXMLNode($0, matchesTag: tag, inNamespace: ns)
-        ? XMLElement(cNode: $0, document: self.document) : nil
-    }
+    return children(tag: tag, inNamespace: ns)
   }
 
   // MARK: - Accessing Content

--- a/Tests/XMLTests.swift
+++ b/Tests/XMLTests.swift
@@ -82,4 +82,11 @@ class XMLTests: XCTestCase {
       XCTAssertFalse(true, "error type should be ParserFailure")
     }
   }
+
+  func testAuthorsByStaticTag() {
+    let authlistElement = document.root!.firstChild(staticTag: "header")?.firstChild(staticTag: "authlist")
+    XCTAssertNotNil(authlistElement, "authorlist element should not be nil")
+    let authorElements = authlistElement?.children(staticTag: "author")
+    XCTAssertEqual(authorElements?.count, 5, "should have 5 elements")
+  }
 }


### PR DESCRIPTION
I hope fast Swift XML parser more fast! (comparable to Objective-C ones!)

Finding children with `func cXMLNode(tag:...)` takes extra cost of Swift.String generation from C String, and thus higher level String comparison `String.compare(...)` consume much cpu time (profiled by Instruments).

`func cXMLNode` takes libxml types. On the other hand, string literals can be converted `UnsafePointer<CChar>` (a.k.a. C String, `UnsafePointer<xmlChar>`, ...) via `Swift.StaticString`. Using StaticString, we can compare libxml tag name to the string on the libxml level `xmlStrcasecmp` without copying memory.

with this PR, `element.children(staticTag: "key")` to get children in better performance 🏎 

I have tried overloading `func children` for both String and StaticString, but string literals seems to fall to String always.
this cause `func firstChild` and `func children` to be duplicated into String version and StaticString versions.