### PR TITLE
Eliminate retain cycles (possible leaks) in lazy var setups

### DIFF
--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -26,12 +26,12 @@ import libxml2
 open class XMLDocument {
   // MARK: - Document Attributes
   /// The XML version.
-  open fileprivate(set) lazy var version: String? = {
+  open fileprivate(set) lazy var version: String? = { [unowned self] in
     return ^-^self.cDocument.pointee.version
   }()
   
   /// The string encoding for the document. This is NSUTF8StringEncoding if no encoding is set, or it cannot be calculated.
-  open fileprivate(set) lazy var encoding: String.Encoding = {
+  open fileprivate(set) lazy var encoding: String.Encoding = { [unowned self] in
     if let encodingName = ^-^self.cDocument.pointee.encoding {
       let encoding = CFStringConvertIANACharSetNameToEncoding(encodingName as CFString!)
       if encoding != kCFStringEncodingInvalidId {

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -26,18 +26,18 @@ import libxml2
 open class XMLElement: XMLNode {
   
   /// The element's namespace.
-  open fileprivate(set) lazy var namespace: String? = {
+  open fileprivate(set) lazy var namespace: String? = { [unowned self] in
     return ^-^(self.cNode.pointee.ns != nil ?self.cNode.pointee.ns.pointee.prefix :nil)
   }()
   
   /// The element's tag.
-  open fileprivate(set) lazy var tag: String? = {
+  open fileprivate(set) lazy var tag: String? = { [unowned self] in
     return ^-^self.cNode.pointee.name
   }()
   
   // MARK: - Accessing Attributes
   /// All attributes for the element.
-  open fileprivate(set) lazy var attributes: [String : String] = {
+  open fileprivate(set) lazy var attributes: [String : String] = { [unowned self] in
     var attributes = [String: String]()
     var attribute = self.cNode.pointee.properties
     while attribute != nil {
@@ -152,12 +152,12 @@ open class XMLElement: XMLNode {
   }
   
   /// A number representation of the element's value, which is generated from the document's `numberFormatter` property.
-  open fileprivate(set) lazy var numberValue: NSNumber? = {
+  open fileprivate(set) lazy var numberValue: NSNumber? = { [unowned self] in
     return self.document.numberFormatter.number(from: self.stringValue)
   }()
   
   /// A date representation of the element's value, which is generated from the document's `dateFormatter` property.
-  open fileprivate(set) lazy var dateValue: Date? = {
+  open fileprivate(set) lazy var dateValue: Date? = { [unowned self] in
     return self.document.dateFormatter.date(from: self.stringValue)
   }()
   

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -96,23 +96,23 @@ open class XMLNode {
   }
   
   /// The element's line number.
-  open fileprivate(set) lazy var lineNumber: Int = {
+  open fileprivate(set) lazy var lineNumber: Int = { [unowned self] in
     return xmlGetLineNo(self.cNode)
   }()
   
   // MARK: - Accessing Parent and Sibling Elements
   /// The element's parent element.
-  open fileprivate(set) lazy var parent: XMLElement? = {
+  open fileprivate(set) lazy var parent: XMLElement? = { [unowned self] in
     return XMLElement(cNode: self.cNode.pointee.parent, document: self.document)
   }()
   
   /// The element's previous sibling.
-  open fileprivate(set) lazy var previousSibling: XMLElement? = {
+  open fileprivate(set) lazy var previousSibling: XMLElement? = { [unowned self] in
     return XMLElement(cNode: self.cNode.pointee.prev, document: self.document)
   }()
 
   /// The element's next sibling.
-  open fileprivate(set) lazy var nextSibling: XMLElement? = {
+  open fileprivate(set) lazy var nextSibling: XMLElement? = { [unowned self] in
     return XMLElement(cNode: self.cNode.pointee.next, document: self.document)
   }()
   
@@ -123,7 +123,7 @@ open class XMLNode {
   }
 
   /// A string representation of the element's value.
-  open fileprivate(set) lazy var stringValue : String = {
+  open fileprivate(set) lazy var stringValue : String = { [unowned self] in
     let key = xmlNodeGetContent(self.cNode)
     let stringValue = ^-^key ?? ""
     xmlFree(key)
@@ -131,7 +131,7 @@ open class XMLNode {
   }()
   
   /// The raw XML string of the element.
-  open fileprivate(set) lazy var rawXML: String = {
+  open fileprivate(set) lazy var rawXML: String = { [unowned self] in
     let buffer = xmlBufferCreate()
     if self.isHTML {
       htmlNodeDump(buffer, self.cNode.pointee.doc, self.cNode)

--- a/Sources/NodeSet.swift
+++ b/Sources/NodeSet.swift
@@ -42,7 +42,7 @@ open class NodeSet: Collection {
   }
 
   /// Number of nodes
-  open fileprivate(set) lazy var count: Int = {
+  open fileprivate(set) lazy var count: Int = { [unowned self] in
     return Int(self.cNodeSet?.pointee.nodeNr ?? 0)
   }()
   

--- a/Sources/Queryable.swift
+++ b/Sources/Queryable.swift
@@ -75,17 +75,17 @@ public protocol Queryable {
 /// Result for evaluating a XPath expression
 open class XPathFunctionResult {
   /// Boolean value
-  open fileprivate(set) lazy var boolValue: Bool = {
+  open fileprivate(set) lazy var boolValue: Bool = { [unowned self] in
     return self.cXPath.pointee.boolval != 0
   }()
   
   /// Double value
-  open fileprivate(set) lazy var doubleValue: Double = {
+  open fileprivate(set) lazy var doubleValue: Double = { [unowned self] in
     return self.cXPath.pointee.floatval
   }()
   
   /// String value
-  open fileprivate(set) lazy var stringValue: String = {
+  open fileprivate(set) lazy var stringValue: String = { [unowned self] in
     return ^-^self.cXPath.pointee.stringval ?? ""
   }()
   


### PR DESCRIPTION
I added `[unowned self] in` to lazy var setups to eliminate retain cycles and possible memory leaks according to [this guide](https://www.raywenderlich.com/134411/arc-memory-management-swift) and like other projects e.g. [xmartlabs/Eureka](https://github.com/xmartlabs/Eureka).

You may consider replacing it with `[weak self]` later to remedy possible crashes but I think it's unnecessary because these properties are called when `self` is not freed. unless you are considering multi-thread scenarios.