### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -122,8 +122,8 @@ $ carthage update
 2. `Build Settings`で`Search Paths`の`Header Search Paths`に`$(SDKROOT)/usr/include/libxml2`を追加してください。
 
 
-##用例
-###XML
+## 用例
+### XML
 ```swift
 import Fuzi
 
@@ -155,7 +155,7 @@ do {
   }
 }
 ```
-###HTML
+### HTML
 `HTMLDocument` は `XMLDocument` サブクラス。
 
 ```swift
@@ -198,7 +198,7 @@ do {
 }
 ```
 
-###エラー処理なんて、どうでもいい場合
+### エラー処理なんて、どうでもいい場合
 
 ```swift
 import Fuzi
@@ -217,7 +217,7 @@ let doc2 = try! HTMLDocument(string: html)
 //...
 ```
 
-###テキストノードを取得したい
+### テキストノードを取得したい
 テキストノードだけではなく、全種類のノードは取得可能。
 
 ```swift

--- a/README-zh.md
+++ b/README-zh.md
@@ -123,8 +123,8 @@ $ carthage update
 2. `Build Settings`中，向`Search Paths`的`Header Search Paths`条目下添加`$(SDKROOT)/usr/include/libxml2`。
 
 
-##例子
-###XML
+## 例子
+### XML
 ```swift
 import Fuzi
 
@@ -156,7 +156,7 @@ do {
   }
 }
 ```
-###HTML
+### HTML
 `HTMLDocument` 是 `XMLDocument` 的子类。
 
 ```swift
@@ -199,7 +199,7 @@ do {
 }
 ```
 
-###如果觉得没必要处理异常
+### 如果觉得没必要处理异常
 
 ```swift
 import Fuzi
@@ -218,7 +218,7 @@ let doc2 = try! HTMLDocument(string: html)
 //...
 ```
 
-###我想访问文字节点
+### 我想访问文字节点
 不仅文字节点，你可以指定你想获取的任何类型的节点。
 
 ```swift
@@ -227,14 +227,14 @@ let document = ...
 document.root?.childNodes(ofTypes: [.Element, .Text, .Comment])
 ```
 
-##从Ono转移到Fuzi
+## 从Ono转移到Fuzi
 下面两个示例程序做的事情是完全一样的，通过比较能很快了解两者的异同。
 
 [Ono示例](https://github.com/mattt/Ono/blob/master/Example/main.m)
 
 [Fuzi示例](FuziDemo/FuziDemo/main.swift)
 
-###访问子节点
+### 访问子节点
 **Ono**
 
 ```objc
@@ -257,7 +257,7 @@ for element in parent.children {
 }
 doc.children(tag: tag, inNamespace:namespace)
 ```
-###迭代查询结果
+### 迭代查询结果
 **Ono**
 
 查询结果实现了`NSFastEnumeration`协议。
@@ -307,7 +307,7 @@ if let nthElement = doc.css(css)[n] {
 // total element count
 let count = doc.xpath(xpath).count
 ```
-###执行XPath函数
+### 执行XPath函数
 **Ono**
 
 ```objc

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Then do the followings in Xcode:
 2. In `Build Settings`, find `Search Paths`, add `$(SDKROOT)/usr/include/libxml2` to `Header Search Paths`.
 
 
-##Usage
-###XML
+## Usage
+### XML
 ```swift
 import Fuzi
 
@@ -158,7 +158,7 @@ do {
   }
 }
 ```
-###HTML
+### HTML
 `HTMLDocument` is a subclass of `XMLDocument`.
 
 ```swift
@@ -201,7 +201,7 @@ do {
 }
 ```
 
-###I don't care about error handling
+### I don't care about error handling
 
 ```swift
 import Fuzi
@@ -220,7 +220,7 @@ let doc2 = try! HTMLDocument(string: html)
 //...
 ```
 
-###I want to access Text Nodes
+### I want to access Text Nodes
 Not only text nodes, you can specify what types of nodes you would like to access.
 
 ```swift
@@ -229,14 +229,14 @@ let document = ...
 document.root?.childNodes(ofTypes: [.Element, .Text, .Comment])
 ```
 
-##Migrating From Ono?
+## Migrating From Ono?
 Looking at example programs is the swiftest way to know the difference. The following 2 examples do exactly the same thing.
 
 [Ono Example](https://github.com/mattt/Ono/blob/master/Example/main.m)
 
 [Fuzi Example](FuziDemo/FuziDemo/main.swift)
 
-###Accessing children
+### Accessing children
 **Ono**
 
 ```objc
@@ -259,7 +259,7 @@ for element in parent.children {
 }
 doc.children(tag: tag, inNamespace:namespace)
 ```
-###Iterate through query results
+### Iterate through query results
 **Ono**
 
 Conforms to `NSFastEnumeration`.
@@ -310,7 +310,7 @@ if let nthElement = doc.css(css)[n] {
 let count = doc.xpath(xpath).count
 ```
 
-###Evaluating XPath Functions
+### Evaluating XPath Functions
 **Ono**
 
 ```objc


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
