### PR TITLE
disable code coverage to allow for app store submission

### DIFF
--- a/Fuzi.xcodeproj/xcshareddata/xcschemes/Fuzi.xcscheme
+++ b/Fuzi.xcodeproj/xcshareddata/xcschemes/Fuzi.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Disable code coverage in Fuzi scheme to allow for app store submission. [See here](https://developer.apple.com/library/content/qa/qa1964/_index.html#//apple_ref/doc/uid/DTS40017675-CH1-INSPECT)