### PR TITLE
Update for Swift 4

### DIFF
--- a/Sources/Queryable.swift
+++ b/Sources/Queryable.swift
@@ -284,15 +284,15 @@ internal func XPath(fromCSS css: String) -> String {
           let nsrange = NSRange(location: 0, length: token.utf16.count)
           
           if let result = RegexConstants.idRegex.firstMatch(in: token, options: [], range: nsrange), result.numberOfRanges > 1 {
-            xpathComponent += "\(symbol)[@id = '\(token[result.range(at: 1)])']"
+            xpathComponent += "\(symbol)[@id = '\(token[result.rangeAt(1)])']"
           }
           
           for result in RegexConstants.classRegex.matches(in: token, options: [], range: nsrange) where result.numberOfRanges > 1 {
-            xpathComponent += "\(symbol)[contains(concat(' ',normalize-space(@class),' '),' \(token[result.range(at: 1)]) ')]"
+            xpathComponent += "\(symbol)[contains(concat(' ',normalize-space(@class),' '),' \(token[result.rangeAt(1)]) ')]"
           }
           
           for result in RegexConstants.attributeRegex.matches(in: token, options: [], range: nsrange) where result.numberOfRanges > 1 {
-            xpathComponent += "[@\(token[result.range(at: 1)])]"
+            xpathComponent += "[@\(token[result.rangeAt(1)])]"
           }
           
           token = xpathComponent


### PR DESCRIPTION
This file wasn't compiling and was throwing Swift 4 errors for `range(at:)` which has changed to `rangeAt(:)`