### PR TITLE
Fix firstChild with namespace crashes parsing sibling non-namespaced nodes

### DIFF
--- a/Sources/Helpers.swift
+++ b/Sources/Helpers.swift
@@ -139,7 +139,7 @@ internal func cXMLNode(_ node: xmlNodePtr?, matchesTag tag: XMLCharsComparable, 
   var matches = tag.caseInsensitivelyEqual(to: name)
 
   if let ns = ns {
-    guard let prefix = node?.pointee.ns.pointee.prefix else {
+    guard let prefix = node?.pointee.ns?.pointee.prefix else {
       return false
     }
     matches = matches && ns.caseInsensitivelyEqual(to: prefix)

--- a/Tests/AtomTests.swift
+++ b/Tests/AtomTests.swift
@@ -101,6 +101,16 @@ class AtomTests: XCTestCase {
     XCTAssertNotNil(namespacedElement.namespace, "the namespace shouldn't be nil")
     XCTAssertEqual(namespacedElement.namespace!, "dc", "Namespaces should match")
   }
+
+  func testFirstChildInNameSpace() {
+    let entryElement = document.root!.firstChild(tag: "entry")
+    XCTAssertNotNil(entryElement, "the element shouldn't be nil")
+
+    let namespacedElement = entryElement!.firstChild(tag: "language", inNamespace: "dc")
+    XCTAssertNotNil(namespacedElement?.namespace, "the namespace shouldn't be nil")
+    XCTAssertEqual(namespacedElement!.namespace, "dc", "Namespace should match")
+    XCTAssertEqual(namespacedElement!.stringValue, "en-us", "value should match")
+  }
   
   func testXPathWithNamespaces() {
     var count = 0


### PR DESCRIPTION
Fixes #70 