### PR TITLE
Remove wrapping libxml2 modulemap for Xcode 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   matrix:
     - DESTINATION="platform=macOS,arch=x86_64" SDK="macosx" ACTION="test"
     - DESTINATION="platform=iOS Simulator,name=iPhone 7" SDK="iphonesimulator" ACTION="test"
-    - DESTINATION="platform=tvOS Simulator,name=Apple TV 1080p" SDK="appletvsimulator" ACTION="test"
+    - DESTINATION="platform=tvOS Simulator,name=Apple TV 4K" SDK="appletvsimulator" ACTION="test"
     - DESTINATION="name=Apple Watch - 38mm" SDK="watchsimulator" ACTION="build"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 
 os: osx
-osx_image: xcode9
+osx_image: xcode9.3beta
 
 env:
   global:

--- a/Fuzi.podspec
+++ b/Fuzi.podspec
@@ -17,12 +17,8 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
 
   s.source_files  = "Sources/*.swift"
-  s.preserve_paths = "libxml2/*"
 
   s.requires_arc = true
   s.library = "xml2"
-  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2', 'SWIFT_INCLUDE_PATHS' => '$(SRCROOT)/Fuzi/libxml2' }
-
-  # Uncomment for `pob lib lint`
-  # s.prepare_command = 'mkdir -p $TMPDIR/CocoaPods/Lint/Pods/Fuzi && cp -r libxml2 $TMPDIR/CocoaPods/Lint/Pods/Fuzi/libxml2'
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
 end

--- a/Fuzi.xcodeproj/project.pbxproj
+++ b/Fuzi.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "-lxml2";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -458,6 +459,7 @@
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = "-lxml2";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/Fuzi.xcodeproj/project.pbxproj
+++ b/Fuzi.xcodeproj/project.pbxproj
@@ -354,7 +354,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.cezheng.Fuzi;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SUPPORTED_PLATFORMS = "macosx iphoneos appletvos watchos iphonesimulator appletvsimulator watchsimulator";
-				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/libxml2";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
@@ -414,7 +413,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.cezheng.Fuzi;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SUPPORTED_PLATFORMS = "macosx iphoneos appletvos watchos iphonesimulator appletvsimulator watchsimulator";
-				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/libxml2";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";

--- a/README-ja.md
+++ b/README-ja.md
@@ -99,11 +99,9 @@ $ pod install
 
 ### 手動で
 1. `Fuzi`フォルダの `*.swift` ファイルをプロジェクトに追加してください。
-2. `libxml2`フォルダをプロジェクトのフォルダのどこか（ `/path/to/somewhere`）にコピペしてください。
-3. Xcode プロジェクトの `Build Settings` で:
-   1. `Swift Compiler - Search Paths`の`Import Paths`に`/path/to/somewhere/libxml2`を追加してください。
-   2. `Search Paths`の`Header Search Paths`に`$(SDKROOT)/usr/include/libxml2`を追加してください。
-   3. `Linking`の`Other Linker Flags`に`-lxml2`を追加してください。
+2. Xcode プロジェクトの `Build Settings` で:
+   1. `Search Paths`の`Header Search Paths`に`$(SDKROOT)/usr/include/libxml2`を追加してください。
+   2. `Linking`の`Other Linker Flags`に`-lxml2`を追加してください。
 
 ### Carthageで
 プロダクトのディレクトリに`Cartfile` か `Cartfile.private`のファイルを作成し、下記の行を追加してください:

--- a/README-zh.md
+++ b/README-zh.md
@@ -100,11 +100,9 @@ $ pod install
 
 ### 手动导入
 1. 将`Fuzi`文件夹下所有`*.swift`文件添加到您的Xcode项目中。
-2. 将`libxml2`文件夹拷到你的项目路径下的某处，下称`/path/to/somewhere`。
-3. 修改Xcode项目的`Build Settings`:
-   1. 向`Swift Compiler - Search Paths`的`Import Paths`条目下添加`/path/to/somewhere/libxml2`。
-   2. 向`Search Paths`的`Header Search Paths`条目下添加`$(SDKROOT)/usr/include/libxml2`。
-   3. 向`Linking`的`Other Linker Flags`条目下添加`-lxml2`。
+2. 修改Xcode项目的`Build Settings`:
+   1. 向`Search Paths`的`Header Search Paths`条目下添加`$(SDKROOT)/usr/include/libxml2`。
+   2. 向`Linking`的`Other Linker Flags`条目下添加`-lxml2`。
 
 ### 通过[Carthage](https://github.com/Carthage/Carthage)
 在项目的根目录下创建名为 `Cartfile` 或 `Cartfile.private`的文件，并加入如下一行:

--- a/README.md
+++ b/README.md
@@ -102,11 +102,9 @@ $ pod install
 
 ### Manually
 1. Add all `*.swift` files in `Fuzi` directory into your project.
-2. Copy `libxml2` folder into somewhere in your project's directory, say `/path/to/somewhere`.
-3. In your Xcode project `Build Settings`:
-   1. Find `Swift Compiler - Search Paths`, add `/path/to/somewhere/libxml2` to `Import Paths`.
-   2. Find `Search Paths`, add `$(SDKROOT)/usr/include/libxml2` to `Header Search Paths`.
-   3. Find `Linking`, add `-lxml2` to `Other Linker Flags`.
+2. In your Xcode project `Build Settings`:
+   1. Find `Search Paths`, add `$(SDKROOT)/usr/include/libxml2` to `Header Search Paths`.
+   2. Find `Linking`, add `-lxml2` to `Other Linker Flags`.
 
 ### Using [Carthage](https://github.com/Carthage/Carthage)
 Create a `Cartfile` or `Cartfile.private` in the root directory of your project, and add the following line:

--- a/libxml2/libxml2-fuzi.h
+++ b/libxml2/libxml2-fuzi.h
@@ -1,5 +1,0 @@
-#import <libxml2/libxml/xmlreader.h>
-#import <libxml2/libxml/xpath.h>
-#import <libxml2/libxml/xpathInternals.h>
-#import <libxml2/libxml/HTMLparser.h>
-#import <libxml2/libxml/HTMLtree.h>

--- a/libxml2/module.modulemap
+++ b/libxml2/module.modulemap
@@ -1,6 +1,0 @@
-module libxml2 [system] {
-  link "xml2"
-  umbrella header "libxml2-fuzi.h"
-  export *
-  module * { export * }
-}


### PR DESCRIPTION
Fixes #77.
Although the issue has been referenced by several PRs, this PR patches in another way, that does remove  `libxml2/module.modulemap` from Fuzi.

The modulemap is no longer needed because Xcode 9.3 has the modulemap in its SDK. (It's not included in Xcode 9.2 and before.)
Accordingly this also removes `SWIFT_INCLUDE_PATHS ` a.k.a. `Import Paths` as it no longer exists, and adds `-lxml2` to the project as README says at the Install Manually section.

