### PR TITLE
Declare additional namespace prefixes to be used with XPath

### DIFF
--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -137,16 +137,16 @@ open class XMLDocument {
   }
   
   // MARK: - XML Namespaces
-  var defaultNamespaces = [String: String]()
+  var namespaces = [String: String]()  // prefix -> URI
   
   /**
-  Define a prefix for a default namespace.
+  Defines a new prefix for the given namespace in XPath expressions.
   
   - parameter prefix: The prefix name
-  - parameter ns:     The default namespace URI that declared in XML Document
+  - parameter ns:     The namespace URI declared in the XML Document
   */
-  open func definePrefix(_ prefix: String, defaultNamespace ns: String) {
-    defaultNamespaces[ns] = prefix
+  open func definePrefix(_ prefix: String, forNamespace ns: String) {
+    namespaces[prefix] = ns
   }
 }
 

--- a/Sources/Queryable.swift
+++ b/Sources/Queryable.swift
@@ -262,10 +262,10 @@ extension XMLElement: Queryable {
     }
     
     func withXMLChar(_ string: String, _ handler: (UnsafePointer<xmlChar>) -> Void) {
-        string.utf8CString
-            .map { xmlChar(bitPattern: $0) }
-            .withUnsafeBufferPointer {
-                handler($0.baseAddress!)
+      string.utf8CString
+        .map { xmlChar(bitPattern: $0) }
+        .withUnsafeBufferPointer {
+          handler($0.baseAddress!)
         }
     }
     
@@ -274,24 +274,24 @@ extension XMLElement: Queryable {
     // Registers namespace prefixes declared in the document.
     var node = cNode
     while node.pointee.parent != nil {
-        var curNs = node.pointee.nsDef
-        while let ns = curNs {
-            var prefixChars = [CChar]()
-            if let prefix = ns.pointee.prefix {
-                xmlXPathRegisterNs(context, prefix, ns.pointee.href)
-            }
-            curNs = ns.pointee.next
+      var curNs = node.pointee.nsDef
+      while let ns = curNs {
+        var prefixChars = [CChar]()
+        if let prefix = ns.pointee.prefix {
+          xmlXPathRegisterNs(context, prefix, ns.pointee.href)
         }
-        node = node.pointee.parent
+        curNs = ns.pointee.next
+      }
+      node = node.pointee.parent
     }
-
+    
     // Registers additional namespace prefixes.
     for (prefix, uri) in document.namespaces {
-        withXMLChar(prefix) { prefix in
-            withXMLChar(uri) { uri in
-                xmlXPathRegisterNs(context, prefix, uri)
-            }
+      withXMLChar(prefix) { prefix in
+        withXMLChar(uri) { uri in
+          xmlXPathRegisterNs(context, prefix, uri)
         }
+      }
     }
     
     defer {

--- a/Tests/AtomTests.swift
+++ b/Tests/AtomTests.swift
@@ -32,7 +32,7 @@ class AtomTests: XCTestCase {
     } catch {
       XCTAssertFalse(true, "Error should not be thrown")
     }
-    document.definePrefix("atom", defaultNamespace: "http://www.w3.org/2005/Atom")
+    document.definePrefix("atom", forNamespace: "http://www.w3.org/2005/Atom")
   }
   
   func testXMLVersion() {

--- a/Tests/AtomTests.swift
+++ b/Tests/AtomTests.swift
@@ -121,4 +121,16 @@ class AtomTests: XCTestCase {
     }
     XCTAssertEqual(count, 1, "should be 1 entry element")
   }
+  
+  func testXPathWithNamespacesAliases() {
+    document.definePrefix("atom-alias", forNamespace: "http://www.w3.org/2005/Atom")
+    document.definePrefix("dc-alias", forNamespace: "http://purl.org/dc/elements/1.1/")
+    
+    var results = document.xpath("//atom-alias:entry/dc-alias:language")
+    XCTAssertEqual(results.map { $0.rawXML }, ["<dc:language>en-us</dc:language>"])
+    XCTAssertEqual(results.first?.namespace, "dc", "The namespace should be the one declared in the document")
+    
+    results = document.xpath("//atom:entry/dc:language")
+    XCTAssertEqual(results.map { $0.rawXML }, ["<dc:language>en-us</dc:language>"], "The default prefixes should still work")
+  }
 }

--- a/Tests/DefaultNamespaceXPathTests.swift
+++ b/Tests/DefaultNamespaceXPathTests.swift
@@ -35,7 +35,7 @@ class DefaultNamespaceXPathTests: XCTestCase {
   }
   
   func testAbsoluteXPathWithDefaultNamespace() {
-    document.definePrefix("ocf", defaultNamespace: "urn:oasis:names:tc:opendocument:xmlns:container")
+    document.definePrefix("ocf", forNamespace: "urn:oasis:names:tc:opendocument:xmlns:container")
     let xpath = "/ocf:container/ocf:rootfiles/ocf:rootfile"
     var count = 0
     for element in document.xpath(xpath) {
@@ -46,7 +46,7 @@ class DefaultNamespaceXPathTests: XCTestCase {
   }
   
   func testRelativeXPathWithDefaultNamespace() {
-    document.definePrefix("ocf", defaultNamespace: "urn:oasis:names:tc:opendocument:xmlns:container")
+    document.definePrefix("ocf", forNamespace: "urn:oasis:names:tc:opendocument:xmlns:container")
     let absoluteXPath = "/ocf:container/ocf:rootfiles"
     let relativeXPath = "./ocf:rootfile"
     var count = 0

--- a/Tests/DefaultNamespaceXPathTests.swift
+++ b/Tests/DefaultNamespaceXPathTests.swift
@@ -58,4 +58,12 @@ class DefaultNamespaceXPathTests: XCTestCase {
     }
     XCTAssertEqual(count, 1, "Element should be found at XPath '\(relativeXPath)' relative to XPath '\(absoluteXPath)'")
   }
+  
+  func testDefaultNamespaceInChildNode() {
+    document.definePrefix("ocf", forNamespace: "urn:oasis:names:tc:opendocument:xmlns:container")
+    document.definePrefix("dc", forNamespace: "http://purl.org/dc/elements/1.1/")
+    let results = document.xpath("/ocf:container/dc:metadata/dc:identifier")
+    XCTAssertEqual(results.map { $0.rawXML }, ["<identifier id=\"pub-id\">urn:uuid:pubid</identifier>"])
+    XCTAssertNil(results.first?.namespace, "The namespace should be empty because none is declared in the document")
+  }
 }

--- a/Tests/Resources/ocf.xml
+++ b/Tests/Resources/ocf.xml
@@ -3,4 +3,8 @@
   <rootfiles>
     <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
   </rootfiles>
+  
+  <metadata xmlns="http://purl.org/dc/elements/1.1/">
+    <identifier id="pub-id">urn:uuid:pubid</identifier>
+  </metadata>
 </container>

--- a/Tests/XPathFunctionResultTests.swift
+++ b/Tests/XPathFunctionResultTests.swift
@@ -32,7 +32,7 @@ class XPathFunctionResultTests: XCTestCase {
     } catch {
       XCTAssertFalse(true, "Error should not be thrown")
     }
-    document.definePrefix("atom", defaultNamespace: "http://www.w3.org/2005/Atom")
+    document.definePrefix("atom", forNamespace: "http://www.w3.org/2005/Atom")
   }
   
   func testFunctionResultBoolValue() {


### PR DESCRIPTION
Fixes #99 

This allows to declare additional namespace prefixes that are not already declared in the document. This is useful to be write XPath expressions without knowing how the document was authored.

Several prefixes can be used for the same namespace, so a node can be queried both using the prefix declared in the document, and the one defined on `XMLDocument`.

(PS: The unit tests are still working with those changes)