### PR TITLE
Update Package definition for Xcode 11.4 beta

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,6 @@ let package = Package(
     targets: [
         .target(name: "Fuzi",
             path: "Sources",
-            
-            // Headers and linking for libxml2
-            cSettings: [.headerSearchPath("$(SDKROOT)/usr/include/libxml2")],
             linkerSettings: [.linkedLibrary("xml2")]
         ),
         .testTarget(name: "FuziTests",


### PR DESCRIPTION
As of Xcode 11.4 beta (2?), `libxml2` can be imported as-is for Packages in Xcode, without indicating any search paths. Linker settings are still required for use. Should finally fix #102